### PR TITLE
Fix incorrect price calculation for MAK spider

### DIFF
--- a/price_scraper/price_scraper/spiders/mak.py
+++ b/price_scraper/price_scraper/spiders/mak.py
@@ -42,10 +42,13 @@ class MakDailySpider(scrapy.Spider):
         """
         content = response.json()
         for product in content['data']['data']:
-            bid_pct = product.get('bidPrice', '1').replace(',', '.')
-            # in some cases they return empty string
+            bid_pct = product.get('bidPrice', '')
+            # when there is an interest payment or close to expiry there is no bidPrice
+            # TODO(blaymoira): implement logic to set this to 100% when the `maturityInDays_val` field is 2 or 3
+            # in that case we should set the date to maturityDate
             if not bid_pct:
-                bid_pct = '1'
+                continue
+            bid_pct.replace(',', '.')
             bid_pct = float(bid_pct) / 100
 
             security_type = product['securityType']

--- a/price_scraper/price_scraper/spiders/mak.py
+++ b/price_scraper/price_scraper/spiders/mak.py
@@ -48,7 +48,7 @@ class MakDailySpider(scrapy.Spider):
             # in that case we should set the date to maturityDate
             if not bid_pct:
                 continue
-            bid_pct.replace(',', '.')
+            bid_pct = bid_pct.replace(',', '.')
             bid_pct = float(bid_pct) / 100
 
             security_type = product['securityType']


### PR DESCRIPTION
It calculated the price incorrectly when there were no bidPrice available. This happens during interest payment or close to expiration.